### PR TITLE
Replace transportHeaders with RoutingContext in STOMP handshake

### DIFF
--- a/src/main/java/io/vertx/ext/stomp/lite/StompServerHandler.java
+++ b/src/main/java/io/vertx/ext/stomp/lite/StompServerHandler.java
@@ -3,6 +3,7 @@ package io.vertx.ext.stomp.lite;
 import io.vertx.core.Future;
 import io.vertx.core.MultiMap;
 import io.vertx.ext.stomp.lite.frame.Frame;
+import io.vertx.ext.web.RoutingContext;
 
 import java.util.Map;
 
@@ -15,13 +16,14 @@ public interface StompServerHandler {
     /**
      * Handles a transport handshake before the STOMP connection is established.
      *
-     * <p>For WebSocket transports, {@code transportHeaders} contains the HTTP upgrade request headers and returned
-     * headers are added to the HTTP upgrade response before it is accepted. A failed future rejects the handshake.</p>
+     * <p>For WebSocket transports, {@code routingContext} provides access to the HTTP upgrade request (including
+     * headers, path parameters, session and user data) and returned headers are added to the HTTP upgrade response
+     * before it is accepted. A failed future rejects the handshake.</p>
      *
-     * @param transportHeaders the headers provided by the transport handshake
+     * @param routingContext the {@link RoutingContext} of the transport handshake request
      * @return a {@link Future} containing headers to return with the transport handshake response
      */
-    Future<MultiMap> handshake(MultiMap transportHeaders);
+    Future<MultiMap> handshake(RoutingContext routingContext);
 
     /**
      * Called when the transport connection has been created.

--- a/src/main/java/io/vertx/ext/stomp/lite/StompServerVerticle.java
+++ b/src/main/java/io/vertx/ext/stomp/lite/StompServerVerticle.java
@@ -65,7 +65,7 @@ public class StompServerVerticle extends VerticleBase {
         requestRouter.route(stompOptions.getWebsocketPath())
                      .handler(context -> {
                          if (context.request().canUpgradeToWebSocket()) {
-                             ssWebSocketHandler.onHttpServerRequest(context.request());
+                             ssWebSocketHandler.onRoutingContext(context);
                          } else {
                              context.response().setStatusCode(HttpResponseStatus.BAD_REQUEST.code()).end();
                          }

--- a/src/main/java/io/vertx/ext/stomp/lite/handler/StompServerWebSocketHandler.java
+++ b/src/main/java/io/vertx/ext/stomp/lite/handler/StompServerWebSocketHandler.java
@@ -27,6 +27,7 @@ import io.vertx.ext.stomp.lite.StompServerHandlerFactory;
 import io.vertx.ext.stomp.lite.StompServerOptions;
 import io.vertx.ext.stomp.lite.frame.FrameParser;
 import io.vertx.ext.stomp.lite.frame.InvalidConnectFrame;
+import io.vertx.ext.web.RoutingContext;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -50,11 +51,12 @@ public class StompServerWebSocketHandler {
         this.factory = factory;
     }
 
-    public void onHttpServerRequest(HttpServerRequest request) {
+    public void onRoutingContext(RoutingContext routingContext) {
+        HttpServerRequest request = routingContext.request();
         request.pause();
         StompServerHandler stompServerHandler = factory.create();
         stompServerHandler
-                .handshake(request.headers())
+                .handshake(routingContext)
                 .onComplete(ar -> {
                     if (ar.succeeded()) {
                         MultiMap responseHeaders = ar.result();


### PR DESCRIPTION
## Summary
This PR refactors the STOMP server handshake mechanism to provide handlers with full access to the HTTP upgrade request context instead of just the headers. This enables handlers to access additional request metadata such as path parameters, session data, and user information.

## Key Changes
- **StompServerHandler interface**: Changed `handshake(MultiMap transportHeaders)` to `handshake(RoutingContext routingContext)` to provide full request context
- **StompServerWebSocketHandler**: 
  - Renamed `onHttpServerRequest()` to `onRoutingContext()` for clarity
  - Updated to pass the `RoutingContext` directly to the handshake method instead of extracting just the headers
- **StompServerVerticle**: Updated the WebSocket upgrade handler to pass the `RoutingContext` to the renamed method
- **Documentation**: Updated JavaDoc to reflect that handlers now have access to HTTP upgrade request details including headers, path parameters, session, and user data

## Implementation Details
The change maintains backward compatibility at the transport level while expanding the capabilities available to STOMP handshake handlers. Handlers can now access the full `RoutingContext` to make more informed decisions during the handshake phase, such as validating user sessions or extracting path-based routing information.

https://claude.ai/code/session_01CJQQsSqW8dKnAnt1VSp6og