### PR TITLE
Fix WebSocket upgrade path to run user-supplied router middleware

### DIFF
--- a/src/main/java/io/vertx/ext/stomp/lite/StompServerVerticle.java
+++ b/src/main/java/io/vertx/ext/stomp/lite/StompServerVerticle.java
@@ -59,28 +59,24 @@ public class StompServerVerticle extends VerticleBase {
 
     @Override
     public Future<?> start() {
-        StompServerWebSocketHandler ssWebSocketHandler
-                = new StompServerWebSocketHandler(vertx, stompOptions, stompServerHandlerFactory);
-        Router requestRouter = Router.router(vertx);
-        requestRouter.route(stompOptions.getWebsocketPath())
-                     .handler(context -> {
-                         if (context.request().canUpgradeToWebSocket()) {
-                             ssWebSocketHandler.onRoutingContext(context);
-                         } else {
-                             context.response().setStatusCode(HttpResponseStatus.BAD_REQUEST.code()).end();
-                         }
-                     });
-        requestRouter.route()
-                     .handler(context -> {
-                         if (router != null) {
-                             router.handle(context.request());
-                         } else {
-                             context.response().setStatusCode(HttpResponseStatus.NOT_FOUND.code()).end();
-                         }
-                     });
+        StompServerWebSocketHandler ssWebSocketHandler =
+                new StompServerWebSocketHandler(vertx, stompOptions, stompServerHandlerFactory);
+
+        Router effectiveRouter = router != null ? router : Router.router(vertx);
+
+        effectiveRouter.route(stompOptions.getWebsocketPath())
+                       .handler(context -> {
+                           if (context.request().canUpgradeToWebSocket()) {
+                               ssWebSocketHandler.onRoutingContext(context);
+                           } else {
+                               context.response()
+                                      .setStatusCode(HttpResponseStatus.BAD_REQUEST.code())
+                                      .end();
+                           }
+                       });
 
         httpServer = vertx.createHttpServer(httpOptions)
-                          .requestHandler(requestRouter)
+                          .requestHandler(effectiveRouter)
                           .exceptionHandler(event -> log.error(
                                   "Stomp server Exception before completing Client Connection",
                                   event));

--- a/src/main/java/io/vertx/ext/stomp/lite/handler/DefaultStompServerConnection.java
+++ b/src/main/java/io/vertx/ext/stomp/lite/handler/DefaultStompServerConnection.java
@@ -317,7 +317,9 @@ class DefaultStompServerConnection implements Handler<Frame>, StompServerConnect
                         throw new IllegalStateException("Unknown command");
                 }
             } catch (Exception e) {
-                clientCausedException(e, false);
+                // Sync throws from the user StompServerHandler (e.g. connect()) must produce
+                // a STOMP ERROR frame so the client sees a diagnostic instead of a bare WS close.
+                clientCausedException(e, true);
             }
         } else {
             log.error("THIS SHOULD NEVER HAPPEN!! Frame Handler called after close.");


### PR DESCRIPTION
StompServerVerticle.start() previously built an internal router that
handled the WebSocket path directly and only delegated to the
user-supplied Router via a catch-all fallback. As a result, any
middleware the caller mounted on the WebSocket path (SessionHandler,
CORS, body handling, etc.) never ran before the STOMP handshake,
leaving the RoutingContext passed into StompServerHandler.handshake(...)
with no session, no body, and no pre-processing.

Mount the WebSocket upgrade handler as the terminal handler on the
user-supplied router at the configured WebSocket path, and use that
router directly as the HttpServer requestHandler.

Contract changes:
- Order of registration now matters. Callers must mount any middleware
  they want to run on the WebSocket path before calling
  StompServerVerticleFactory.create(...); the factory appends the
  upgrade handler last.
- A null router argument is still accepted; an empty router is used
  internally. Non-WS paths return 404 via Vert.x's default routing
  (functionally identical to before).
- The previous behavior of returning 400 when the WS path is hit
  without a WebSocket upgrade is preserved.