### PR TITLE
Upgrade Vert.x from 5.0.12 to 5.1.4

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -17,7 +17,7 @@ ext {
     apacheCommonsVersion='3.20.0'
     logbackVersion='1.5.25'
     nettyVersion='4.1.115.Final'
-    vertxVersion='5.0.12'
+    vertxVersion='5.1.4'
 }
 
 


### PR DESCRIPTION
## Summary
This pull request upgrades the Vert.x dependency to a newer minor version, updating from 5.0.12 to 5.1.4.

## Changes
- Updated `vertxVersion` property in build.gradle from `5.0.12` to `5.1.4`

## Notes
This upgrade brings bug fixes and improvements from the Vert.x 5.1.x release line while maintaining compatibility with the existing 5.x API.

https://claude.ai/code/session_01HewQtJFT42QLcJtC9DLbMC