### PR TITLE
Bump version to 5.6.1

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -5,7 +5,7 @@ plugins {
 }
 
 group 'org.kinotic'
-version '5.6.0'
+version '5.6.1'
 
 sourceCompatibility = '21'
 


### PR DESCRIPTION
## Summary
Bumps the project version on `master` from `5.6.0` → `5.6.1` so a release publish succeeds — `5.6.0` is already released to Maven Central, so re-publishing at that version fails.

## Changes
- Project version: `5.6.0` → `5.6.1`

## Notes
- Vert.x is already at `5.1.4` on `master` (from #5); this PR only touches the version.
- Companion PR #6 brings the same Vert.x bump and a `5.6.1-SNAPSHOT` version onto `develop`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01HewQtJFT42QLcJtC9DLbMC)_