### PR TITLE
Bump develop version to 5.7.0-SNAPSHOT

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -5,7 +5,7 @@ plugins {
 }
 
 group 'org.kinotic'
-version '5.6.1-SNAPSHOT'
+version '5.7.0-SNAPSHOT'
 
 sourceCompatibility = '21'
 


### PR DESCRIPTION
## Summary
`develop` merged in at `5.6.1-SNAPSHOT`, but the snapshot line should track the next minor. This moves it to `5.7.0-SNAPSHOT`.

## Changes
- Project version: `5.6.1-SNAPSHOT` → `5.7.0-SNAPSHOT`

## Notes
- Vert.x is already `5.1.4` on `develop`; this PR only touches the version line.
- `master` remains at the `5.6.1` release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01HewQtJFT42QLcJtC9DLbMC)_