### PR TITLE
Remove hardcoded host and port configuration from StompServerOptions

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -5,7 +5,7 @@ plugins {
 }
 
 group 'org.kinotic'
-version '5.7.0-SNAPSHOT'
+version '6.0.0-SNAPSHOT'
 
 sourceCompatibility = '21'
 

--- a/src/main/java/io/vertx/ext/stomp/lite/StompServerOptions.java
+++ b/src/main/java/io/vertx/ext/stomp/lite/StompServerOptions.java
@@ -16,8 +16,6 @@ public class StompServerOptions {
   public static final int DEFAULT_MAX_BODY_LENGTH = 1024 * 1024 * 10;
 
   public static final String DEFAULT_WEBSOCKET_PATH = "/stomp";
-  public static int DEFAULT_STOMP_PORT = 61613;
-  public static String DEFAULT_STOMP_HOST = "0.0.0.0";
 
   public static JsonObject DEFAULT_STOMP_HEARTBEAT = new JsonObject().put("x", 30000).put("y", 30000);
   public static boolean DEFAULT_TRAILING_LINE = false;
@@ -32,8 +30,6 @@ public class StompServerOptions {
 
   private String websocketPath = DEFAULT_WEBSOCKET_PATH;
   private boolean trailingLine = DEFAULT_TRAILING_LINE;
-  private int port;
-  private String host;
   private boolean debugEnabled = DEFAULT_DEBUG_ENABLED;
 
   /**
@@ -41,8 +37,6 @@ public class StompServerOptions {
    */
   public StompServerOptions() {
     super();
-    setPort(DEFAULT_STOMP_PORT);
-    setHost(DEFAULT_STOMP_HOST);
   }
 
   /**
@@ -124,42 +118,6 @@ public class StompServerOptions {
   public StompServerOptions setMaxHeaders(int maxHeaders) {
     this.maxHeaders = maxHeaders;
     return this;
-  }
-
-  /**
-   * Sets the port on which the server is going to listen for connections.
-   *
-   * @param port the port number
-   * @return the current {@link StompServerOptions}.
-   */
-  public StompServerOptions setPort(int port) {
-    this.port = port;
-    return this;
-  }
-
-  /**
-   * @return the port
-   */
-  public int getPort() {
-    return port;
-  }
-
-  /**
-   * Set the host
-   * @param host  the host
-   * @return a reference to this, so the API can be used fluently
-   */
-  public StompServerOptions setHost(String host) {
-    this.host = host;
-    return this;
-  }
-
-  /**
-   *
-   * @return the host
-   */
-  public String getHost(){
-    return host;
   }
 
   /**

--- a/src/main/java/io/vertx/ext/stomp/lite/StompServerVerticle.java
+++ b/src/main/java/io/vertx/ext/stomp/lite/StompServerVerticle.java
@@ -81,7 +81,7 @@ public class StompServerVerticle extends VerticleBase {
                                   "Stomp server Exception before completing Client Connection",
                                   event));
 
-        return httpServer.listen(stompOptions.getPort(), stompOptions.getHost());
+        return httpServer.listen();
     }
 
     @Override


### PR DESCRIPTION
## Summary
This PR removes the hardcoded host and port configuration from the STOMP server implementation, allowing the HTTP server to use its default listening behavior instead.

## Key Changes
- Removed `DEFAULT_STOMP_PORT` and `DEFAULT_STOMP_HOST` constants from `StompServerOptions`
- Removed `port` and `host` instance fields from `StompServerOptions`
- Removed `setPort()`, `getPort()`, `setHost()`, and `getHost()` methods from `StompServerOptions`
- Removed initialization of port and host in the `StompServerOptions` default constructor
- Updated `StompServerVerticle.start()` to call `httpServer.listen()` without explicit host and port parameters, allowing the HTTP server to use its default configuration

## Implementation Details
The change simplifies the STOMP server configuration by delegating host and port management to the underlying HTTP server's defaults, rather than enforcing specific values (port 61613, host 0.0.0.0) at the STOMP options level. This provides more flexibility and reduces configuration coupling.

https://claude.ai/code/session_01XprtJSfdBTP2R29hbBavmx